### PR TITLE
Changed flag type for GetFileData()

### DIFF
--- a/NewWindowChur/adminuser.cpp
+++ b/NewWindowChur/adminuser.cpp
@@ -18,7 +18,7 @@ adminuser::adminuser(QWidget *parent) :
     ui(new Ui::adminuser)
 
 {
-    QStringList membersData = CreateFiles::GetFileData("members");
+    QStringList membersData = CreateFiles::GetFileData(CSVFiles::_Members);
     ui->setupUi(this);
     QPixmap Img(":/images/YoobeeLibraries.png");
     ui->img->setPixmap(Img.scaled(150, 150, Qt::KeepAspectRatio));

--- a/NewWindowChur/catalogue.cpp
+++ b/NewWindowChur/catalogue.cpp
@@ -48,11 +48,8 @@ Catalogue::Catalogue(QWidget *parent) :
 {
     ui->setupUi(this);
 
-    //QPixmap img(":/images/yoobee-logo.png");
-    //ui->yoobeeLogo->setPixmap(img);
-
     // Array control
-    QStringList catalogue = CreateFiles::GetFileData("catalogue");
+    QStringList catalogue = CreateFiles::GetFileData(CSVFiles::_Catalogue);
     const int arraySize = (catalogue.size() / 5) - 1;
 
     // LAYOUTS
@@ -148,7 +145,7 @@ Catalogue::~Catalogue()
 void Catalogue::on_yourAccount_logout_clicked()
 {
     close();
-    emit ClosedMainMenu();
+    emit OpenMainMenu();
 }
 
 // Search bar functionality

--- a/NewWindowChur/catalogue.h
+++ b/NewWindowChur/catalogue.h
@@ -18,10 +18,7 @@ public:
     //static void CreateCatalogue();
 
 signals:
-    void ClosedMainMenu();
-//    static void BookNameSignal(QString bookName);
-//    static void BookAuthorSignal(QString bookAuthor);
-//    static void BookCopiesSignal(QString bookCopies);
+    void OpenMainMenu();
 
 private slots:
     void on_yourAccount_logout_clicked();

--- a/NewWindowChur/createfiles.cpp
+++ b/NewWindowChur/createfiles.cpp
@@ -8,7 +8,7 @@
 // CreateFiles::_fileNeeded;
 //
 // If you need some files data, you can call
-// CreateFiles::GetFileData("fileNeeded") into a QStringList.
+// CreateFiles::GetFileData(CSVFiles::_YourFile) into a QStringList.
 //
 // ------------------------------------------------------------
 
@@ -62,12 +62,12 @@ void CreateFiles::CreateFilesOnStartUp()
     }
 }
 
-QStringList CreateFiles::GetFileData(QString file)
+QStringList CreateFiles::GetFileData(enum CSVFiles file)
 {
     QStringList fileData;
-
-    if (file == "catalogue")
+    switch (file)
     {
+    case CSVFiles::_Catalogue:
         if (_catalogue.open(QIODevice::ReadOnly))
         {
             QTextStream in(&_catalogue);
@@ -82,9 +82,8 @@ QStringList CreateFiles::GetFileData(QString file)
             return fileData;
         }
         _catalogue.close();
-    }
-    else if (file == "members")
-    {
+        break;
+    case CSVFiles::_Members:
         if (_members.open(QIODevice::ReadOnly))
         {
             QTextStream in(&_members);
@@ -99,9 +98,8 @@ QStringList CreateFiles::GetFileData(QString file)
             return fileData;
         }
         _members.close();
-    }
-    else if (file == "checkedOutBooks")
-    {
+        break;
+    case CSVFiles::_CheckedOutBooks:
         if (_checkedOutBooks.open(QIODevice::ReadOnly))
         {
             QTextStream in(&_checkedOutBooks);
@@ -116,13 +114,12 @@ QStringList CreateFiles::GetFileData(QString file)
             return fileData;
         }
         _checkedOutBooks.close();
+        break;
+    default:
+        qDebug() << "Could not open file.";
+        fileData = {"error"};
+        break;
     }
-    else
-    {
-        QStringList error = {"error"};
-        return error;
-    }
-
     return fileData;
 }
 
@@ -135,7 +132,7 @@ void CreateFiles::CreateMember(QString fName, QString lName, QString uName, QStr
     // Generate the members ID
     quint32 idNum = QRandomGenerator::global()->bounded(1000, 9999);
     QString id = "Mem" + QString::number(idNum);
-    QStringList membersList = GetFileData("members");
+    QStringList membersList = GetFileData(CSVFiles::_Members);
     if (membersList.contains(id))
     {
         while (membersList.contains(id))

--- a/NewWindowChur/createfiles.h
+++ b/NewWindowChur/createfiles.h
@@ -5,27 +5,26 @@
 #include <QTextStream>
 #include <QMessageBox>
 
+enum CSVFiles
+{
+    _Catalogue,
+    _Members,
+    _CheckedOutBooks
+};
+
 class CreateFiles
 {
 public:
-    enum FileFlag
-    {
-        catalogue = 1,
-        members = 2,
-        checkedOut = 3
-    };
-
     CreateFiles();
 
     static void CreateFilesOnStartUp();
+    static QStringList GetFileData(enum CSVFiles);
+    static void CreateMember(QString fName, QString lName, QString uName, QString pWord, QString email, QString phoneNum);
 
     static QString _path;
     static QFile _catalogue;
     static QFile _members;
     static QFile _checkedOutBooks;
-
-    static QStringList GetFileData(QString file);
-    static void CreateMember(QString fName, QString lName, QString uName, QString pWord, QString email, QString phoneNum);
 };
 
 #endif // CREATEFILES_H

--- a/NewWindowChur/mainwindow.cpp
+++ b/NewWindowChur/mainwindow.cpp
@@ -34,10 +34,10 @@ void MainWindow::on_login_clicked()
     QString user = ui->username_input->text(); //Username Input  // - liv
     QString pass = ui->password_input->text(); //password input // - liv
 
-    QStringList a = CreateFiles::GetFileData("members");
+    QStringList a = CreateFiles::GetFileData(CSVFiles::_Members);
 
-    int foundUser = a.indexOf(QRegExp(user));
-    int foundPass = a.indexOf(QRegExp(pass));
+    //int foundUser = a.indexOf(user);
+    //int foundPass = a.indexOf(pass);
 
     //Login password & username for a normal user (not admin)  // - liv
     if(user == "test" && pass == "test"){

--- a/NewWindowChur/signupscreen.cpp
+++ b/NewWindowChur/signupscreen.cpp
@@ -65,8 +65,8 @@ void signupscreen::on_close_clicked()
 // If username is already taken, it will not let the user create an account.
 void signupscreen::on_Username_textChanged(const QString &arg1)
 {
-    QStringList membersList = CreateFiles::GetFileData("members");
-    int index = membersList.indexOf(QRegExp(arg1));
+    QStringList membersList = CreateFiles::GetFileData(CSVFiles::_Members);
+    int index = membersList.indexOf(arg1);
 
     if(arg1 == "")
     {


### PR DESCRIPTION
CreateFiles::GetFileData(QString file) has been changed to:
CreateFiles::GetFileData(CSVFiles::_YourFile)

The parameter has been changed to an enum type call CSVFiles. Previously, having a QString as the parameter allowed for typos resulting in the program crashing or not outputting anything to the user as no data was returned.

Having the new CSVFiles::_YourFile insures that the programmer will know before running that there is an issue as IntelliSense will underline the function red.

Any file that used CreateFiles::GetFileData() should have hopefully been updated, although some may have been missed.