### PR TITLE
Checkout works, updated login

### DIFF
--- a/NewWindowChur/catalogue.cpp
+++ b/NewWindowChur/catalogue.cpp
@@ -101,7 +101,7 @@ Catalogue::Catalogue(QWidget *parent, QString memName, QString memID) :
         checkoutScreen[row] = new CheckOutScreen;
         connect(checkoutButton[row], SIGNAL(clicked()), checkoutScreen[row], SLOT(exec()));
         // Book ID, Book Name, Member ID, Member Name, Date
-        checkoutScreen[row]->setVariables(memName, memID, catalogue[t + 2], catalogue[t + 3], catalogue[t + 4]);
+        checkoutScreen[row]->setVariables(memName, memID, catalogue[t], catalogue[t + 2], catalogue[t + 3], catalogue[t + 4]);
 
         // Horizontal Lines
         lines1[row] = new QFrame();
@@ -161,7 +161,7 @@ void Catalogue::on_searchBar_textChanged(const QString &arg1)
         while(!in.atEnd())
         {
             QString line = CreateFiles::_catalogue.readLine().replace("\r\n","");
-            if (line != "BOOK ID, IMAGE, BOOK NAME, AUTHOR, COPIES")
+            if (line != "BOOK ID, IMAGE, BOOK NAME, AUTHOR, COPIES") // These are the headers of the CSV file. This just skips over it.
             {
                 if (line.toLower().contains(arg1.toLower()))
                 {

--- a/NewWindowChur/checkoutscreen.cpp
+++ b/NewWindowChur/checkoutscreen.cpp
@@ -12,6 +12,7 @@
 #include "checkoutscreen.h"
 #include "ui_checkoutscreen.h"
 #include "createfiles.h"
+#include <QDate>
 
 CheckOutScreen::CheckOutScreen(QWidget *parent) :
     QDialog(parent),
@@ -30,12 +31,14 @@ void CheckOutScreen::on_cancel_clicked()
     close();
 }
 
-void CheckOutScreen::setVariables(QString memName, QString memID, QString bookName, QString authorName, QString copies)
+// This function is called from catalogue.cpp when creating the CheckOutScreen array.
+void CheckOutScreen::setVariables(QString memName, QString memID, QString bookID, QString bookName, QString authorName, QString copies)
 {
+    _membersID = memID;
+    _membersName = memName;
+    _bookID = bookID;
+    _bookName = bookName;
 
-    membersID = memID;
-    membersName = memName;
-    ui->memName->setText(membersName);
     ui->book_name_label->setText(bookName);
     ui->book_author_label->setText(authorName);
     ui->book_copies_label->setText(copies);
@@ -43,15 +46,36 @@ void CheckOutScreen::setVariables(QString memName, QString memID, QString bookNa
 
 void CheckOutScreen::on_checkoutNow_clicked()
 {
-//    QString memberName;
-//    int foundMemId = 0;
-//    QStringList membersList = CreateFiles::GetFileData("members");
+    bool yesChecked = false;
 
-//    foundMemId = membersList.indexOf(QRegExp(membersID));
-//    if (foundMemId > 0)
-//    {
+    QMessageBox* confirmCheckout = new QMessageBox(nullptr);
+    confirmCheckout->setWindowTitle("Checkout Confirmation");
+    confirmCheckout->setText("Are you sure you want to checkout this book?");
+    confirmCheckout->setStandardButtons(QMessageBox::Yes | QMessageBox::Cancel);
+    confirmCheckout->setDefaultButton(QMessageBox::Yes);
+    int result = confirmCheckout->exec();
 
-//    }
+    switch(result)
+    {
+    case QMessageBox::Yes:
+        CreateFiles::CheckOutBook(_bookID, _bookName, _membersID, _membersName);
+        yesChecked = true;
+        break;
+    case QMessageBox::Cancel:
+        confirmCheckout->close();
+        break;
+    default: break;
+    }
 
+    if (yesChecked)
+    {
+        QString dueDate = QDate::currentDate().addDays(7).toString();
+        QMessageBox* confirmed = new QMessageBox(nullptr);
+        confirmed->setWindowTitle("Checkout Confirmed");
+        confirmed->setText("You have successfully checked out " + _bookName + "!<br> "
+                           "It is due on " + dueDate);
+       confirmed->exec();
+       this->close();
+    }
 }
 

--- a/NewWindowChur/checkoutscreen.h
+++ b/NewWindowChur/checkoutscreen.h
@@ -15,7 +15,7 @@ public:
     explicit CheckOutScreen(QWidget *parent = nullptr);
     ~CheckOutScreen();
 
-    void setVariables(QString memName, QString memID, QString bookName, QString authorName, QString copies);
+    void setVariables(QString memName, QString memID, QString bookID, QString bookName, QString authorName, QString copies);
 
 private slots:
     void on_cancel_clicked();
@@ -23,7 +23,7 @@ private slots:
     void on_checkoutNow_clicked();
 
 private:
-    QString membersID, membersName;
+    QString _membersID, _membersName, _bookID, _bookName;
     Ui::CheckOutScreen *ui;
 };
 

--- a/NewWindowChur/checkoutscreen.ui
+++ b/NewWindowChur/checkoutscreen.ui
@@ -222,19 +222,6 @@ border-color: #e7e7e7;
     <string>Author</string>
    </property>
   </widget>
-  <widget class="QLabel" name="memName">
-   <property name="geometry">
-    <rect>
-     <x>250</x>
-     <y>130</y>
-     <width>141</width>
-     <height>16</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string>members name</string>
-   </property>
-  </widget>
  </widget>
  <tabstops>
   <tabstop>checkoutNow</tabstop>

--- a/NewWindowChur/createfiles.cpp
+++ b/NewWindowChur/createfiles.cpp
@@ -16,6 +16,7 @@
 #include <QDebug>
 #include <QRandomGenerator>
 #include <QDebug>
+#include <QDate>
 
 // Defining static variables
 QString CreateFiles::_path = "CSVFiles/";
@@ -41,7 +42,7 @@ void CreateFiles::CreateFilesOnStartUp()
         catalogue_output << "BOOK ID" << "," << "IMAGE" << "," << "BOOK NAME" << "," << "AUTHOR" << "," << "COPIES" << "\n";
         for (int i = 0; i < 20; i++)
         {
-            if (i % 2 == 0)
+            if (i % 2 == 0) // Maybe change how we create a book ID
             {
                 catalogue_output << QString::number(i) << "," << ":/images/blue-book.jpg" << "," << "This is a book" << "," << "Author" << "," << "10" << "\n";
             }
@@ -149,4 +150,16 @@ void CreateFiles::CreateMember(QString fName, QString lName, QString uName, QStr
     QTextStream in(&_members);
     in << id << "," << fName << "," << lName << "," << uName << "," << pWord << "," << email << "," << phoneNum << "\n";
     _members.close();
+}
+
+void CreateFiles::CheckOutBook(QString bookID, QString bookName, QString memID, QString memName)
+{
+    // Get the current date and due date
+    QString currentDate = QDate::currentDate().toString();
+    QString dueDate = QDate::currentDate().addDays(7).toString();
+
+    _checkedOutBooks.open(QIODevice::WriteOnly | QFile::Append | QFile::Text);
+    QTextStream in(&_checkedOutBooks);
+    in << bookID << "," << bookName << "," << memID << "," << memName << "," << currentDate << "," << dueDate << "\n";
+    _checkedOutBooks.close();
 }

--- a/NewWindowChur/createfiles.h
+++ b/NewWindowChur/createfiles.h
@@ -20,6 +20,7 @@ public:
     static void CreateFilesOnStartUp();
     static QStringList GetFileData(enum CSVFiles);
     static void CreateMember(QString fName, QString lName, QString uName, QString pWord, QString email, QString phoneNum);
+    static void CheckOutBook(QString bookID, QString bookName, QString memID, QString memName);
 
     static QString _path;
     static QFile _catalogue;

--- a/NewWindowChur/loginscreen.cpp
+++ b/NewWindowChur/loginscreen.cpp
@@ -7,6 +7,7 @@
 #include <QPushButton>
 
  // - liv (Worked on Login/Signup/Menu Screens)
+// Jakob - connected the signup screens and made the login functional
 
 loginscreen::loginscreen(QWidget *parent) :
     QDialog(parent),
@@ -40,22 +41,47 @@ void loginscreen::on_login_clicked()
     else
     {
         // Checking if the inputs exist in the members file
-        QStringList a = CreateFiles::GetFileData(CSVFiles::_Members);
-        int foundUser = a.indexOf(user);
-        int foundPass = a.indexOf(pass);
+        QStringList membersData = CreateFiles::GetFileData(CSVFiles::_Members);
+
+        int col = 0;
+        bool foundUser = false;
+        int usernameIndex;
+        int passwordIndex;
+        for (int i = 0; i < membersData.size(); i++)
+        {
+            if (col == 3) // Only check for username and password once we reach the username column.
+            {
+                if (user == membersData[i])
+                {
+                    if (pass == membersData[i + 1])
+                    {
+                        foundUser = true;
+                        usernameIndex = i;
+                        passwordIndex = i + 1;
+                    }
+                }
+            }
+            else if (col == 6)
+            {
+                col = 0; // Reset columns back to 0 since there are only 6 columns in members.csv
+            }
+            else
+            {
+              col++;
+            }
+        }
 
         // indexOf returns a positive number if it found the username or password
-        if (foundUser > 0 && foundPass > 0)
+        if (foundUser)
         {
-            QString memName = a[foundUser - 2];
-            QString memID = a[foundUser - 3];
+            QString memName = membersData[usernameIndex - 2];
+            QString memID = membersData[passwordIndex - 3];
             hide();
             // CALL YOUR DIALOG WINDOWS WITH (nullptr) SO THAT THEY HAVE A TASKBAR ICON
             _catalogueWindow = new Catalogue(nullptr, memName, memID);
             _catalogueWindow->setWindowFlags(windowFlags() | Qt::WindowMinimizeButtonHint);
             _catalogueWindow->showMaximized();
             connect(_catalogueWindow, SIGNAL(OpenMainMenu()), this, SLOT(LoginScreenOpen()));
-            //_catalogueWindow->setVariables(memName, memID);
         }
         else
         {

--- a/NewWindowChur/signupscreen.cpp
+++ b/NewWindowChur/signupscreen.cpp
@@ -39,6 +39,7 @@ void signupscreen::on_Next_clicked(){
     _signup2 = new signupscreen2(nullptr);
     _signup2->setWindowFlags(windowFlags() | Qt::WindowMinimizeButtonHint);
     _signup2->show();
+    connect(_signup2, SIGNAL(OpenLoginScreen()), this, SLOT(on_close_clicked()));
     close();
 }
 

--- a/NewWindowChur/signupscreen2.cpp
+++ b/NewWindowChur/signupscreen2.cpp
@@ -32,7 +32,7 @@ signupscreen2::~signupscreen2()
 
 void signupscreen2::on_close_clicked(){ //function for - when the user clicks close
     close();
-    emit OpenMainMenu();
+    emit OpenLoginScreen();
 }
 
 void signupscreen2::on_Next_clicked()

--- a/NewWindowChur/signupscreen2.h
+++ b/NewWindowChur/signupscreen2.h
@@ -20,7 +20,8 @@ public:
     ~signupscreen2();
 
 signals:
-    void OpenMainMenu();
+    void OpenLoginScreen();
+
 private slots:
   void on_close_clicked();//function - for when the user clicks the "close" button
   void on_Next_clicked(); //function - for when the user clicks the "next" button


### PR DESCRIPTION
CheckOutScreen can now actually check out a book.
- The users name and ID is recorded alongside the book name and book ID in checkedOutBooks.csv
- The date checked out and the due date are recorded as well.

I updated the login from using membersData.indexOf(username/password).
Reason being that it would just find the first spot that a username or password is found in the csv. For instance, if someone's username was '1', and a person before them had a phone number starting with 1, it would record that phone number as the username.
The changes made now are:
- Only search for the username and password once we've reached the username column.
- Set a bool to see if membersData[i] and membersData[i + 1] (the password column) match the user and pass.

This is just insures we are always checking in the username and password columns rather than accidentally checking in an id column/phone number column etc.